### PR TITLE
Add mobile control overlay with give up option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,13 @@ const COLORS = {
 - Press 'M' - Force minimap toggle
 - Press 'R' - Regenerate maze with same seed
 
+### Mobile Input Overlay
+- Touch/joystick logic lives in `js/ui/ControlOverlay.js`.
+- Two pads: left = movement (forward/back/strafe), right = rotation.
+- Overlay MENU exposes `RESET_RUN` (regenerate) and `GIVE_UP` (reveals fog of war via `FogOfWar.revealAll`).
+- Use `MatrixRunnerApp._setInputMode()` when altering input behaviour so desktop/mobile stay in sync.
+- Debug helpers exist for QA: `window.DEBUG.enableMobileControls()`, `window.DEBUG.enableDesktopControls()`, `window.DEBUG.autoControls()`.
+
 ### Console Commands (expose in dev)
 ```javascript
 window.DEBUG = {

--- a/css/style.css
+++ b/css/style.css
@@ -113,6 +113,7 @@ body {
   gap: 0.5rem;
   align-items: center;
   pointer-events: none;
+  z-index: 8;
 }
 
 .notification {
@@ -193,10 +194,204 @@ body {
   border-color: var(--error-color);
   color: var(--error-color);
 }
+
+.notification-warning {
+  border-color: var(--warning-color);
+  color: var(--warning-color);
+}
 .menu-header p {
   margin: 0 0 1rem 0;
   font-size: 0.8rem;
   color: rgba(224, 224, 224, 0.8);
+}
+
+.control-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding: 1.5rem;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 6;
+}
+
+.control-overlay[data-visible="true"] {
+  opacity: 1;
+}
+
+.control-overlay__slot {
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.control-overlay__joystick {
+  position: relative;
+  width: 140px;
+  height: 140px;
+  border: 2px solid var(--accent-color);
+  border-radius: 50%;
+  background: rgba(10, 10, 10, 0.45);
+  backdrop-filter: blur(4px);
+  pointer-events: auto;
+  touch-action: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.2s ease;
+}
+
+.control-overlay[data-visible="true"] .control-overlay__joystick {
+  box-shadow: 0 0 16px rgba(0, 255, 255, 0.18);
+}
+
+.control-overlay__ring {
+  position: absolute;
+  inset: 12%;
+  border: 1px solid rgba(0, 255, 255, 0.25);
+  border-radius: 50%;
+  box-shadow: inset 0 0 18px rgba(0, 255, 255, 0.12);
+}
+
+.control-overlay__thumb {
+  position: absolute;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: 2px solid var(--accent-color);
+  background: rgba(0, 255, 255, 0.2);
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  transition: transform 0.08s ease;
+}
+
+.control-overlay__label {
+  position: absolute;
+  bottom: -2.25rem;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.65rem;
+  letter-spacing: 0.16em;
+  color: var(--accent-color);
+  pointer-events: none;
+  user-select: none;
+}
+
+.control-overlay__menu {
+  position: absolute;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  pointer-events: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.control-overlay[data-visible="true"] .control-overlay__menu {
+  pointer-events: auto;
+}
+
+.control-overlay__menu-button {
+  padding: 0.65rem 1.75rem;
+  background: rgba(10, 10, 10, 0.92);
+  border: 2px solid var(--accent-color);
+  color: var(--text-color);
+  font-family: inherit;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.control-overlay__menu-button:hover,
+.control-overlay__menu-button:focus {
+  background: var(--accent-color);
+  color: var(--bg-color);
+  outline: none;
+}
+
+.control-overlay__menu-panel {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-bottom: 0.75rem;
+  padding: 0.75rem 1rem;
+  min-width: 12rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  background: rgba(10, 10, 10, 0.95);
+  border: 2px solid var(--accent-color);
+  box-shadow: 0 0 16px rgba(0, 255, 255, 0.2);
+}
+
+.control-overlay__menu-panel button {
+  padding: 0.5rem;
+  background: transparent;
+  border: 1px solid var(--accent-color);
+  color: var(--text-color);
+  font-family: inherit;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.control-overlay__menu-panel button:hover,
+.control-overlay__menu-panel button:focus {
+  background: var(--accent-color);
+  color: var(--bg-color);
+  outline: none;
+}
+
+.control-overlay[data-visible="false"] .control-overlay__joystick,
+.control-overlay[data-visible="false"] .control-overlay__menu {
+  pointer-events: none;
+}
+
+@media (max-width: 900px) {
+  .control-overlay__joystick {
+    width: 120px;
+    height: 120px;
+  }
+
+  .control-overlay__label {
+    bottom: -2rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .control-overlay {
+    padding: 1rem;
+  }
+
+  .control-overlay__joystick {
+    width: 100px;
+    height: 100px;
+  }
+
+  .control-overlay__thumb {
+    width: 48px;
+    height: 48px;
+  }
+
+  .control-overlay__menu-button {
+    padding: 0.5rem 1.25rem;
+    font-size: 0.7rem;
+  }
+
+  .control-overlay__menu-panel {
+    min-width: 10rem;
+  }
 }
 
 .menu-actions {

--- a/js/main.js
+++ b/js/main.js
@@ -13,6 +13,7 @@ import ViewFrustum from "./rendering/ViewFrustum.js";
 import MenuSystem from "./ui/MenuSystem.js";
 import HUD from "./ui/HUD.js";
 import Notifications from "./ui/Notifications.js";
+import ControlOverlay from "./ui/ControlOverlay.js";
 
 class MatrixRunnerApp {
   constructor() {
@@ -22,6 +23,18 @@ class MatrixRunnerApp {
     this.hudElement = document.getElementById("hud");
     this.menuElement = document.getElementById("menu");
     this.notificationElement = document.getElementById("notifications");
+    this.appElement = document.getElementById("app") ?? document.body;
+
+    const nav = typeof navigator !== "undefined" ? navigator : null;
+    const maxTouchPoints = nav ? Math.max(nav.maxTouchPoints || 0, nav.msMaxTouchPoints || 0) : 0;
+    this._coarsePointerQuery = typeof window.matchMedia === "function"
+      ? window.matchMedia("(pointer: coarse)")
+      : null;
+    const coarsePointer = this._coarsePointerQuery ? this._coarsePointerQuery.matches : false;
+    const touchCapable = "ontouchstart" in window || maxTouchPoints > 0;
+    this._inputModeOverride = null;
+    this._coarsePointerListener = null;
+    this._inputMode = coarsePointer || touchCapable ? "mobile" : "desktop";
 
     this.camera = new Camera();
     this.viewFrustum = new ViewFrustum(this.camera);
@@ -36,13 +49,37 @@ class MatrixRunnerApp {
     this.camera.setMaze(this.mazeData);
     this.camera.setCollisionSystem(this.collisionSystem);
 
-    this.playerController = new PlayerController(this.canvas, this.camera, this.state);
+    this.playerController = new PlayerController(this.canvas, this.camera, this.state, {
+      enablePointerLock: this._inputMode !== "mobile"
+    });
     this.minimapRenderer = new MinimapRenderer(this.minimapCanvas);
     this.minimapRenderer.setMaze(this.mazeData, this.fogOfWar);
 
     this.menu = new MenuSystem(this.menuElement, this.state);
     this.hud = new HUD(this.hudElement, this.state);
     this.notifications = new Notifications(this.notificationElement);
+    this.controlOverlay = new ControlOverlay(this.appElement, {
+      playerController: this.playerController,
+      onReset: () => this._handleRegenerateRequest(),
+      onGiveUp: () => this._handleGiveUp()
+    });
+    this.controlOverlay.setPhase(this.state.phase);
+    this.state.subscribe("state:phase", (phase) => {
+      this.controlOverlay.setPhase(phase);
+    });
+
+    this._setInputMode(this._inputMode, { force: true });
+    if (this._coarsePointerQuery) {
+      this._coarsePointerListener = (event) => {
+        const nextMode = event.matches ? "mobile" : "desktop";
+        this._setInputMode(nextMode);
+      };
+      if (typeof this._coarsePointerQuery.addEventListener === "function") {
+        this._coarsePointerQuery.addEventListener("change", this._coarsePointerListener);
+      } else if (typeof this._coarsePointerQuery.addListener === "function") {
+        this._coarsePointerQuery.addListener(this._coarsePointerListener);
+      }
+    }
 
     this._fps = 0;
     this._lastTimestamp = performance.now();
@@ -121,6 +158,15 @@ class MatrixRunnerApp {
     this.state.setPhase("running");
   }
 
+  _handleGiveUp() {
+    if (this.state.phase !== "running") {
+      return;
+    }
+    this.fogOfWar.revealAll();
+    this.state.recordExploration(1);
+    this.notifications.warning("FOG_OVERRIDE_ENGAGED");
+  }
+
   _pauseGame() {
     if (this.state.phase !== "running") {
       return;
@@ -191,9 +237,10 @@ class MatrixRunnerApp {
     this.collisionSystem.setMaze(this.mazeData);
     this.camera.setMaze(this.mazeData);
     this.camera.setPosition(0.5, 0.5);
-    this.playerController.movement.forward = 0;
-    this.playerController.movement.strafe = 0;
-    this.playerController.movement.rotate = 0;
+    this.playerController.resetMovement();
+    if (this.controlOverlay) {
+      this.controlOverlay.reset();
+    }
     this.minimapRenderer.setMaze(this.mazeData, this.fogOfWar);
 
     this._exitPosition = {
@@ -216,6 +263,42 @@ class MatrixRunnerApp {
     const width = window.innerWidth;
     const height = window.innerHeight;
     this.dotRenderer.resize(width, height);
+  }
+
+  _determineAutomaticInputMode() {
+    const coarsePointer = this._coarsePointerQuery ? this._coarsePointerQuery.matches : false;
+    const nav = typeof navigator !== "undefined" ? navigator : null;
+    const maxTouchPoints = nav ? Math.max(nav.maxTouchPoints || 0, nav.msMaxTouchPoints || 0) : 0;
+    const touchCapable = "ontouchstart" in window || maxTouchPoints > 0;
+    return coarsePointer || touchCapable ? "mobile" : "desktop";
+  }
+
+  _setInputMode(mode, options = {}) {
+    const target = mode === "mobile" ? "mobile" : "desktop";
+    if (options.override) {
+      this._inputModeOverride = target;
+    } else if (this._inputModeOverride && !options.force) {
+      return;
+    }
+    if (this._inputMode === target && !options.force) {
+      return;
+    }
+    this._inputMode = target;
+    if (this.playerController && typeof this.playerController.setPointerLockEnabled === "function") {
+      this.playerController.setPointerLockEnabled(target !== "mobile");
+    }
+    if (this.controlOverlay) {
+      this.controlOverlay.setEnabled(target === "mobile");
+      if (target === "mobile") {
+        this.controlOverlay.reset();
+      }
+    }
+  }
+
+  _clearInputModeOverride() {
+    this._inputModeOverride = null;
+    const next = this._determineAutomaticInputMode();
+    this._setInputMode(next, { force: true });
   }
 
   _loop(timestamp) {
@@ -292,16 +375,15 @@ class MatrixRunnerApp {
         }
       },
       revealAll: () => {
-        const indices = new Uint32Array(this.mazeData.width * this.mazeData.height);
-        for (let i = 0; i < indices.length; i += 1) {
-          indices[i] = i;
-        }
-        this.fogOfWar.setVisibleCells(indices);
+        this.fogOfWar.revealAll();
         this.state.recordExploration(1);
       },
       showPerf: () => this.state.toggleDebugFlag("showFPS"),
       pause: () => this._pauseGame(),
-      resume: () => this._resumeGame()
+      resume: () => this._resumeGame(),
+      enableMobileControls: () => this._setInputMode("mobile", { override: true, force: true }),
+      enableDesktopControls: () => this._setInputMode("desktop", { override: true, force: true }),
+      autoControls: () => this._clearInputModeOverride()
     };
   }
 }

--- a/js/maze/FogOfWar.js
+++ b/js/maze/FogOfWar.js
@@ -16,6 +16,16 @@
     this.explored.fill(0);
   }
 
+  revealAll() {
+    this.visible.fill(1);
+    this.explored.fill(0xff);
+    const remainder = this.cellCount & 7;
+    if (remainder !== 0 && this.explored.length > 0) {
+      const mask = (1 << remainder) - 1;
+      this.explored[this.explored.length - 1] = mask;
+    }
+  }
+
   setVisibleCells(cells) {
     this.visible.fill(0);
     for (let i = 0; i < cells.length; i += 1) {

--- a/js/player/PlayerController.js
+++ b/js/player/PlayerController.js
@@ -1,10 +1,14 @@
 ﻿import Constants from "../core/Constants.js";
 
 class PlayerController {
-  constructor(canvas, camera, gameState) {
+  constructor(canvas, camera, gameState, options = {}) {
     this.canvas = canvas;
     this.camera = camera;
     this.gameState = gameState;
+    this.inputSources = {
+      keyboard: { forward: 0, strafe: 0, rotate: 0 },
+      overlay: { forward: 0, strafe: 0, rotate: 0 }
+    };
     this.movement = {
       forward: 0,
       strafe: 0,
@@ -12,6 +16,7 @@ class PlayerController {
     };
     this.sensitivity = 0.0025;
     this.isPointerLocked = false;
+    this.enablePointerLock = options.enablePointerLock !== false;
 
     this._bindEvents();
   }
@@ -30,6 +35,37 @@ class PlayerController {
     document.addEventListener("pointerlockerror", this._onPointerLockError);
     document.addEventListener("mousemove", this._onMouseMove);
     this.canvas.addEventListener("click", this._onCanvasClick);
+  }
+
+  setOverlayVector(vector = {}) {
+    const source = this.inputSources.overlay;
+    source.forward = this._normalizeAxis(vector.forward);
+    source.strafe = this._normalizeAxis(vector.strafe);
+    source.rotate = this._normalizeAxis(vector.rotate);
+    this._updateMovement();
+  }
+
+  setPointerLockEnabled(enabled) {
+    const next = Boolean(enabled);
+    if (this.enablePointerLock === next) {
+      return;
+    }
+    this.enablePointerLock = next;
+    if (!this.enablePointerLock && document.pointerLockElement === this.canvas) {
+      document.exitPointerLock();
+    }
+    this.isPointerLocked = this.enablePointerLock && document.pointerLockElement === this.canvas;
+  }
+
+  resetMovement() {
+    const { keyboard, overlay } = this.inputSources;
+    keyboard.forward = 0;
+    keyboard.strafe = 0;
+    keyboard.rotate = 0;
+    overlay.forward = 0;
+    overlay.strafe = 0;
+    overlay.rotate = 0;
+    this._updateMovement();
   }
 
   dispose() {
@@ -55,25 +91,25 @@ class PlayerController {
     switch (event.code) {
       case "KeyW":
       case "ArrowUp":
-        this.movement.forward = 1;
+        this.inputSources.keyboard.forward = 1;
         break;
       case "KeyS":
       case "ArrowDown":
-        this.movement.forward = -1;
+        this.inputSources.keyboard.forward = -1;
         break;
       case "KeyA":
       case "ArrowLeft":
-        this.movement.strafe = -1;
+        this.inputSources.keyboard.strafe = -1;
         break;
       case "KeyD":
       case "ArrowRight":
-        this.movement.strafe = 1;
+        this.inputSources.keyboard.strafe = 1;
         break;
       case "KeyQ":
-        this.movement.rotate = -1;
+        this.inputSources.keyboard.rotate = -1;
         break;
       case "KeyE":
-        this.movement.rotate = 1;
+        this.inputSources.keyboard.rotate = 1;
         break;
       case Constants.DEBUG_KEYS.TOGGLE_DEBUG:
         this.gameState.toggleDebugFlag("showDebugOverlay");
@@ -96,51 +132,53 @@ class PlayerController {
       default:
         break;
     }
+    this._updateMovement();
   }
 
   _handleKeyUp(event) {
     switch (event.code) {
       case "KeyW":
       case "ArrowUp":
-        if (this.movement.forward === 1) {
-          this.movement.forward = 0;
+        if (this.inputSources.keyboard.forward === 1) {
+          this.inputSources.keyboard.forward = 0;
         }
         break;
       case "KeyS":
       case "ArrowDown":
-        if (this.movement.forward === -1) {
-          this.movement.forward = 0;
+        if (this.inputSources.keyboard.forward === -1) {
+          this.inputSources.keyboard.forward = 0;
         }
         break;
       case "KeyA":
       case "ArrowLeft":
-        if (this.movement.strafe === -1) {
-          this.movement.strafe = 0;
+        if (this.inputSources.keyboard.strafe === -1) {
+          this.inputSources.keyboard.strafe = 0;
         }
         break;
       case "KeyD":
       case "ArrowRight":
-        if (this.movement.strafe === 1) {
-          this.movement.strafe = 0;
+        if (this.inputSources.keyboard.strafe === 1) {
+          this.inputSources.keyboard.strafe = 0;
         }
         break;
       case "KeyQ":
-        if (this.movement.rotate === -1) {
-          this.movement.rotate = 0;
+        if (this.inputSources.keyboard.rotate === -1) {
+          this.inputSources.keyboard.rotate = 0;
         }
         break;
       case "KeyE":
-        if (this.movement.rotate === 1) {
-          this.movement.rotate = 0;
+        if (this.inputSources.keyboard.rotate === 1) {
+          this.inputSources.keyboard.rotate = 0;
         }
         break;
       default:
         break;
     }
+    this._updateMovement();
   }
 
   _handleMouseMove(event) {
-    if (!this.isPointerLocked) {
+    if (!this.enablePointerLock || !this.isPointerLocked) {
       return;
     }
     const delta = event.movementX * this.sensitivity;
@@ -153,14 +191,41 @@ class PlayerController {
     if (this.gameState.phase !== "running") {
       return;
     }
-    if (document.pointerLockElement === this.canvas) {
+    if (!this.enablePointerLock || document.pointerLockElement === this.canvas) {
       return;
     }
     this.canvas.requestPointerLock();
   }
 
+  _normalizeAxis(value) {
+    if (!Number.isFinite(value)) {
+      return 0;
+    }
+    if (Math.abs(value) < 0.0001) {
+      return 0;
+    }
+    return Math.max(-1, Math.min(1, value));
+  }
+
+  _updateMovement() {
+    const { keyboard, overlay } = this.inputSources;
+    this.movement.forward = this._clampAxis(keyboard.forward + overlay.forward);
+    this.movement.strafe = this._clampAxis(keyboard.strafe + overlay.strafe);
+    this.movement.rotate = this._clampAxis(keyboard.rotate + overlay.rotate);
+  }
+
+  _clampAxis(value) {
+    if (value > 1) {
+      return 1;
+    }
+    if (value < -1) {
+      return -1;
+    }
+    return value;
+  }
+
   _handlePointerLockChange() {
-    this.isPointerLocked = document.pointerLockElement === this.canvas;
+    this.isPointerLocked = this.enablePointerLock && document.pointerLockElement === this.canvas;
   }
 
   _handlePointerLockError() {

--- a/js/ui/ControlOverlay.js
+++ b/js/ui/ControlOverlay.js
@@ -1,0 +1,274 @@
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+class ControlOverlay {
+  constructor(rootElement, options = {}) {
+    this.rootElement = rootElement;
+    this.playerController = options.playerController;
+    this.onReset = typeof options.onReset === "function" ? options.onReset : () => {};
+    this.onGiveUp = typeof options.onGiveUp === "function" ? options.onGiveUp : () => {};
+    this._phase = options.phase ?? "boot";
+    this._enabled = options.enabled ?? false;
+    this._visible = false;
+
+    this._moveState = { pointerId: null };
+    this._lookState = { pointerId: null };
+    this._overlayInput = { forward: 0, strafe: 0, rotate: 0 };
+
+    this._build();
+    this._bindJoysticks();
+    this._bindMenu();
+    this._updateVisibility();
+  }
+
+  setEnabled(enabled) {
+    if (this._enabled === enabled) {
+      return;
+    }
+    this._enabled = enabled;
+    this._updateVisibility();
+  }
+
+  setPhase(phase) {
+    if (this._phase === phase) {
+      return;
+    }
+    this._phase = phase;
+    this._updateVisibility();
+  }
+
+  reset() {
+    this._resetMoveJoystick();
+    this._resetLookJoystick();
+    this._overlayInput.forward = 0;
+    this._overlayInput.strafe = 0;
+    this._overlayInput.rotate = 0;
+    this._applyOverlayInput();
+    this._closeMenu();
+  }
+
+  _build() {
+    this.element = document.createElement("div");
+    this.element.className = "control-overlay";
+    this.element.setAttribute("data-visible", "false");
+    this.element.innerHTML = `
+      <div class="control-overlay__slot control-overlay__slot--left">
+        <div class="control-overlay__joystick" data-joystick="move" aria-label="Movement control">
+          <div class="control-overlay__ring"></div>
+          <div class="control-overlay__thumb"></div>
+          <div class="control-overlay__label">MOVE</div>
+        </div>
+      </div>
+      <div class="control-overlay__slot control-overlay__slot--right">
+        <div class="control-overlay__joystick" data-joystick="look" aria-label="Rotation control">
+          <div class="control-overlay__ring"></div>
+          <div class="control-overlay__thumb"></div>
+          <div class="control-overlay__label">LOOK</div>
+        </div>
+      </div>
+      <div class="control-overlay__menu" data-menu>
+        <button type="button" class="control-overlay__menu-button">MENU</button>
+        <div class="control-overlay__menu-panel" hidden>
+          <button type="button" data-action="reset">RESET_RUN</button>
+          <button type="button" data-action="giveup">GIVE_UP</button>
+          <button type="button" data-action="close">CLOSE_PANEL</button>
+        </div>
+      </div>
+    `;
+    this.rootElement.appendChild(this.element);
+
+    this.moveJoystick = this.element.querySelector('[data-joystick="move"]');
+    this.lookJoystick = this.element.querySelector('[data-joystick="look"]');
+    this.menu = this.element.querySelector("[data-menu]");
+    this.menuButton = this.menu.querySelector(".control-overlay__menu-button");
+    this.menuPanel = this.menu.querySelector(".control-overlay__menu-panel");
+  }
+
+  _bindJoysticks() {
+    this._bindMoveJoystick();
+    this._bindLookJoystick();
+  }
+
+  _bindMoveJoystick() {
+    const handlePointerDown = (event) => {
+      event.preventDefault();
+      this.moveJoystick.setPointerCapture(event.pointerId);
+      this._moveState.pointerId = event.pointerId;
+      this._updateMoveJoystick(event);
+    };
+
+    const handlePointerMove = (event) => {
+      if (this._moveState.pointerId !== event.pointerId) {
+        return;
+      }
+      this._updateMoveJoystick(event);
+    };
+
+    const endInteraction = (event) => {
+      if (this._moveState.pointerId !== event.pointerId) {
+        return;
+      }
+      this.moveJoystick.releasePointerCapture(event.pointerId);
+      this._moveState.pointerId = null;
+      this._resetMoveJoystick();
+      this._overlayInput.forward = 0;
+      this._overlayInput.strafe = 0;
+      this._applyOverlayInput();
+    };
+
+    this.moveJoystick.addEventListener("pointerdown", handlePointerDown);
+    this.moveJoystick.addEventListener("pointermove", handlePointerMove);
+    this.moveJoystick.addEventListener("pointerup", endInteraction);
+    this.moveJoystick.addEventListener("pointercancel", endInteraction);
+  }
+
+  _bindLookJoystick() {
+    const handlePointerDown = (event) => {
+      event.preventDefault();
+      this.lookJoystick.setPointerCapture(event.pointerId);
+      this._lookState.pointerId = event.pointerId;
+      this._updateLookJoystick(event);
+    };
+
+    const handlePointerMove = (event) => {
+      if (this._lookState.pointerId !== event.pointerId) {
+        return;
+      }
+      this._updateLookJoystick(event);
+    };
+
+    const endInteraction = (event) => {
+      if (this._lookState.pointerId !== event.pointerId) {
+        return;
+      }
+      this.lookJoystick.releasePointerCapture(event.pointerId);
+      this._lookState.pointerId = null;
+      this._resetLookJoystick();
+      this._overlayInput.rotate = 0;
+      this._applyOverlayInput();
+    };
+
+    this.lookJoystick.addEventListener("pointerdown", handlePointerDown);
+    this.lookJoystick.addEventListener("pointermove", handlePointerMove);
+    this.lookJoystick.addEventListener("pointerup", endInteraction);
+    this.lookJoystick.addEventListener("pointercancel", endInteraction);
+  }
+
+  _bindMenu() {
+    this.menuButton.addEventListener("click", () => {
+      if (this.menuPanel.hasAttribute("hidden")) {
+        this._openMenu();
+      } else {
+        this._closeMenu();
+      }
+    });
+
+    this.menuPanel.addEventListener("click", (event) => {
+      const button = event.target.closest("button[data-action]");
+      if (!button) {
+        return;
+      }
+      const action = button.getAttribute("data-action");
+      switch (action) {
+        case "reset":
+          this._closeMenu();
+          this.onReset();
+          break;
+        case "giveup":
+          this._closeMenu();
+          this.onGiveUp();
+          break;
+        case "close":
+        default:
+          this._closeMenu();
+          break;
+      }
+    });
+  }
+
+  _openMenu() {
+    this.menuPanel.removeAttribute("hidden");
+  }
+
+  _closeMenu() {
+    this.menuPanel.setAttribute("hidden", "");
+  }
+
+  _updateMoveJoystick(event) {
+    const rect = this.moveJoystick.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+    const dx = event.clientX - centerX;
+    const dy = event.clientY - centerY;
+    const radius = rect.width / 2;
+    const distance = Math.min(Math.hypot(dx, dy), radius);
+    const angle = Math.atan2(dy, dx);
+    const normalizedX = clamp((distance * Math.cos(angle)) / radius, -1, 1);
+    const normalizedY = clamp((distance * Math.sin(angle)) / radius, -1, 1);
+
+    const thumb = this.moveJoystick.querySelector(".control-overlay__thumb");
+    const maxOffset = radius * 0.6;
+    thumb.style.transform = `translate(calc(-50% + ${normalizedX * maxOffset}px), calc(-50% + ${normalizedY * maxOffset}px))`;
+
+    const strafe = Math.abs(normalizedX) < 0.1 ? 0 : normalizedX;
+    const forward = Math.abs(normalizedY) < 0.1 ? 0 : -normalizedY;
+    this._overlayInput.forward = clamp(forward, -1, 1);
+    this._overlayInput.strafe = clamp(strafe, -1, 1);
+    this._applyOverlayInput();
+  }
+
+  _updateLookJoystick(event) {
+    const rect = this.lookJoystick.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+    const dx = event.clientX - centerX;
+    const dy = event.clientY - centerY;
+    const radius = rect.width / 2;
+    const distance = Math.min(Math.hypot(dx, dy), radius);
+    const angle = Math.atan2(dy, dx);
+    const normalizedX = clamp((distance * Math.cos(angle)) / radius, -1, 1);
+    const normalizedY = clamp((distance * Math.sin(angle)) / radius, -1, 1);
+
+    const thumb = this.lookJoystick.querySelector(".control-overlay__thumb");
+    const maxOffset = radius * 0.6;
+    thumb.style.transform = `translate(calc(-50% + ${normalizedX * maxOffset}px), calc(-50% + ${normalizedY * maxOffset}px))`;
+
+    const rotate = Math.abs(normalizedX) < 0.08 ? 0 : normalizedX;
+    this._overlayInput.rotate = clamp(rotate, -1, 1);
+    this._applyOverlayInput();
+  }
+
+  _resetMoveJoystick() {
+    const thumb = this.moveJoystick.querySelector(".control-overlay__thumb");
+    thumb.style.transform = "translate(-50%, -50%)";
+  }
+
+  _resetLookJoystick() {
+    const thumb = this.lookJoystick.querySelector(".control-overlay__thumb");
+    thumb.style.transform = "translate(-50%, -50%)";
+  }
+
+  _applyOverlayInput() {
+    if (!this.playerController || typeof this.playerController.setOverlayVector !== "function") {
+      return;
+    }
+    this.playerController.setOverlayVector({
+      forward: this._overlayInput.forward,
+      strafe: this._overlayInput.strafe,
+      rotate: this._overlayInput.rotate
+    });
+  }
+
+  _updateVisibility() {
+    const shouldShow = this._enabled && this._phase === "running";
+    if (this._visible === shouldShow) {
+      return;
+    }
+    this._visible = shouldShow;
+    this.element.setAttribute("data-visible", shouldShow ? "true" : "false");
+    if (!shouldShow) {
+      this.reset();
+    }
+  }
+}
+
+export default ControlOverlay;

--- a/js/ui/Notifications.js
+++ b/js/ui/Notifications.js
@@ -12,6 +12,10 @@
     this.push(message, "success");
   }
 
+  warning(message) {
+    this.push(message, "warning");
+  }
+
   error(message) {
     this.push(message, "error");
   }

--- a/prd.md
+++ b/prd.md
@@ -101,6 +101,12 @@ Create an immersive maze exploration experience that feels like navigating throu
 - Optional movement sound effects
 - Breadcrumb trail option (temporary path marking)
 
+**Mobile/Touch Controls**
+- Detect coarse pointer/touch devices and surface a dual-joystick overlay.
+- Left pad drives forward/back + strafe movement, right pad handles rotation.
+- Central menu button offers `RESET_RUN` (regenerate maze) and `GIVE_UP` (reveal fog of war) actions.
+- Maintain feature parity: on-screen controls respond to touch and pointer events so desktop browsers can test mobile mode.
+
 ## Technical Specifications
 
 ### Rendering Engine


### PR DESCRIPTION
## Summary
- add a ControlOverlay UI with dual virtual joysticks and an in-game menu button for reset or give up
- detect coarse pointer devices to toggle mobile mode, disable pointer lock, and wire give up to reveal fog of war
- update supporting systems (fog of war, player controller, notifications, styling, docs) for parity between mobile and desktop

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ceadc4d4ac8324858c1e1daa5a2694