### PR TITLE
Fix menu toggling for desktop and mobile modes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -346,6 +346,10 @@ body {
   box-shadow: 0 0 16px rgba(0, 255, 255, 0.2);
 }
 
+.control-overlay__menu-panel[hidden] {
+  display: none;
+}
+
 .control-overlay__menu-panel button {
   padding: 0.5rem;
   background: transparent;

--- a/js/player/PlayerController.js
+++ b/js/player/PlayerController.js
@@ -127,6 +127,11 @@ class PlayerController {
         this.gameState.emit("maze:regenerate");
         break;
       case "Escape":
+        if (this.gameState.phase === "running") {
+          this.gameState.emit("ui:pauseRequested");
+        } else if (this.gameState.phase === "paused") {
+          this.gameState.emit("ui:resumeRequested");
+        }
         document.exitPointerLock();
         break;
       default:
@@ -225,7 +230,11 @@ class PlayerController {
   }
 
   _handlePointerLockChange() {
+    const wasLocked = this.isPointerLocked;
     this.isPointerLocked = this.enablePointerLock && document.pointerLockElement === this.canvas;
+    if (wasLocked && !this.isPointerLocked && this.gameState.phase === "running") {
+      this.gameState.emit("ui:pauseRequested");
+    }
   }
 
   _handlePointerLockError() {

--- a/js/ui/ControlOverlay.js
+++ b/js/ui/ControlOverlay.js
@@ -1,5 +1,7 @@
 const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
 
+let overlayMenuCounter = 0;
+
 class ControlOverlay {
   constructor(rootElement, options = {}) {
     this.rootElement = rootElement;
@@ -9,6 +11,7 @@ class ControlOverlay {
     this._phase = options.phase ?? "boot";
     this._enabled = options.enabled ?? false;
     this._visible = false;
+    this._menuOpen = false;
 
     this._moveState = { pointerId: null };
     this._lookState = { pointerId: null };
@@ -81,6 +84,12 @@ class ControlOverlay {
     this.menu = this.element.querySelector("[data-menu]");
     this.menuButton = this.menu.querySelector(".control-overlay__menu-button");
     this.menuPanel = this.menu.querySelector(".control-overlay__menu-panel");
+    this._menuPanelId = `control-overlay-menu-panel-${overlayMenuCounter++}`;
+    this.menuPanel.id = this._menuPanelId;
+    this.menuPanel.hidden = true;
+    this.menuButton.setAttribute("aria-haspopup", "true");
+    this.menuButton.setAttribute("aria-controls", this._menuPanelId);
+    this.menuButton.setAttribute("aria-expanded", "false");
   }
 
   _bindJoysticks() {
@@ -155,10 +164,10 @@ class ControlOverlay {
 
   _bindMenu() {
     this.menuButton.addEventListener("click", () => {
-      if (this.menuPanel.hasAttribute("hidden")) {
-        this._openMenu();
-      } else {
+      if (this._menuOpen) {
         this._closeMenu();
+      } else {
+        this._openMenu();
       }
     });
 
@@ -186,11 +195,18 @@ class ControlOverlay {
   }
 
   _openMenu() {
-    this.menuPanel.removeAttribute("hidden");
+    if (this._menuOpen) {
+      return;
+    }
+    this._menuOpen = true;
+    this.menuPanel.hidden = false;
+    this.menuButton.setAttribute("aria-expanded", "true");
   }
 
   _closeMenu() {
-    this.menuPanel.setAttribute("hidden", "");
+    this._menuOpen = false;
+    this.menuPanel.hidden = true;
+    this.menuButton.setAttribute("aria-expanded", "false");
   }
 
   _updateMoveJoystick(event) {


### PR DESCRIPTION
## Summary
- allow the Escape key and pointer lock changes to route through the pause/resume flow so the desktop menu is reachable
- improve the mobile control overlay menu by tracking its open state, wiring accessibility attributes, and reliably hiding it when closed
- add CSS to ensure the hidden overlay menu panel is visually removed

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ceef67bcc88324aa0c905a13b6fed0