### PR TITLE
Improve menu access across input modes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -67,6 +67,41 @@ body {
   text-transform: uppercase;
 }
 
+#hud .hud-button {
+  margin-top: 0.75rem;
+  padding: 0.45rem 0.9rem;
+  background: transparent;
+  border: 1px solid var(--accent-color);
+  color: var(--accent-color);
+  font-family: inherit;
+  font-size: 0.7rem;
+  text-transform: inherit;
+  letter-spacing: 0.14em;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+#hud .hud-button:hover,
+#hud .hud-button:focus {
+  background: var(--accent-color);
+  color: var(--bg-color);
+  outline: none;
+}
+
+#hud .hud-button[disabled],
+#hud .hud-button[aria-disabled="true"] {
+  opacity: 0.4;
+  cursor: not-allowed;
+  background: transparent;
+  color: rgba(224, 224, 224, 0.6);
+  border-color: rgba(0, 255, 255, 0.4);
+}
+
+#hud .hud-button--active {
+  background: var(--accent-color);
+  color: var(--bg-color);
+}
+
 #menu {
   position: absolute;
   inset: 0;
@@ -344,6 +379,10 @@ body {
   background: rgba(10, 10, 10, 0.95);
   border: 2px solid var(--accent-color);
   box-shadow: 0 0 16px rgba(0, 255, 255, 0.2);
+}
+
+.control-overlay__menu-panel[hidden] {
+  display: none;
 }
 
 .control-overlay__menu-panel button {

--- a/js/core/PointerLock.js
+++ b/js/core/PointerLock.js
@@ -1,0 +1,53 @@
+const getDocument = () => (typeof document !== "undefined" ? document : null);
+
+export const getPointerLockElement = () => {
+  const doc = getDocument();
+  if (!doc) {
+    return null;
+  }
+  return (
+    doc.pointerLockElement ||
+    doc.mozPointerLockElement ||
+    doc.webkitPointerLockElement ||
+    null
+  );
+};
+
+export const exitPointerLock = () => {
+  const doc = getDocument();
+  if (!doc) {
+    return;
+  }
+  const exit =
+    doc.exitPointerLock || doc.mozExitPointerLock || doc.webkitExitPointerLock;
+  if (typeof exit === "function") {
+    exit.call(doc);
+  }
+};
+
+export const requestPointerLock = (element) => {
+  if (!element) {
+    return false;
+  }
+  const request =
+    element.requestPointerLock ||
+    element.mozRequestPointerLock ||
+    element.webkitRequestPointerLock;
+  if (typeof request === "function") {
+    request.call(element);
+    return true;
+  }
+  return false;
+};
+
+export const POINTER_LOCK_CHANGE_EVENTS = [
+  "pointerlockchange",
+  "mozpointerlockchange",
+  "webkitpointerlockchange"
+];
+
+export const POINTER_LOCK_ERROR_EVENTS = [
+  "pointerlockerror",
+  "mozpointerlockerror",
+  "webkitpointerlockerror"
+];

--- a/js/main.js
+++ b/js/main.js
@@ -14,6 +14,7 @@ import MenuSystem from "./ui/MenuSystem.js";
 import HUD from "./ui/HUD.js";
 import Notifications from "./ui/Notifications.js";
 import ControlOverlay from "./ui/ControlOverlay.js";
+import { exitPointerLock } from "./core/PointerLock.js";
 
 class MatrixRunnerApp {
   constructor() {
@@ -172,7 +173,7 @@ class MatrixRunnerApp {
       return;
     }
     this.state.setPhase("paused");
-    document.exitPointerLock();
+    exitPointerLock();
     this.menu.show({ mode: "pause" });
     this.notifications.info("SIMULATION_PAUSED");
   }
@@ -187,7 +188,7 @@ class MatrixRunnerApp {
   }
 
     _abortRunToMenu(message, level = "info") {
-    document.exitPointerLock();
+    exitPointerLock();
     this._runCompleted = false;
     this.menu.show({ mode: "launch", ...this.state.mazeConfig });
     this.state.setPhase("menu");
@@ -347,7 +348,7 @@ class MatrixRunnerApp {
 
   _handleRunComplete() {
     this._runCompleted = true;
-    document.exitPointerLock();
+    exitPointerLock();
     const stats = this._collectRunStats();
     this._lastStats = stats;
     this.state.setPhase("complete");

--- a/js/player/PlayerController.js
+++ b/js/player/PlayerController.js
@@ -1,4 +1,11 @@
-﻿import Constants from "../core/Constants.js";
+import Constants from "../core/Constants.js";
+import {
+  exitPointerLock,
+  getPointerLockElement,
+  POINTER_LOCK_CHANGE_EVENTS,
+  POINTER_LOCK_ERROR_EVENTS,
+  requestPointerLock
+} from "../core/PointerLock.js";
 
 class PlayerController {
   constructor(canvas, camera, gameState, options = {}) {
@@ -17,6 +24,8 @@ class PlayerController {
     this.sensitivity = 0.0025;
     this.isPointerLocked = false;
     this.enablePointerLock = options.enablePointerLock !== false;
+    this._pointerLockChangeEvents = POINTER_LOCK_CHANGE_EVENTS;
+    this._pointerLockErrorEvents = POINTER_LOCK_ERROR_EVENTS;
 
     this._bindEvents();
   }
@@ -31,8 +40,12 @@ class PlayerController {
 
     window.addEventListener("keydown", this._onKeyDown);
     window.addEventListener("keyup", this._onKeyUp);
-    document.addEventListener("pointerlockchange", this._onPointerLockChange);
-    document.addEventListener("pointerlockerror", this._onPointerLockError);
+    this._pointerLockChangeEvents.forEach((eventName) => {
+      document.addEventListener(eventName, this._onPointerLockChange);
+    });
+    this._pointerLockErrorEvents.forEach((eventName) => {
+      document.addEventListener(eventName, this._onPointerLockError);
+    });
     document.addEventListener("mousemove", this._onMouseMove);
     this.canvas.addEventListener("click", this._onCanvasClick);
   }
@@ -51,10 +64,14 @@ class PlayerController {
       return;
     }
     this.enablePointerLock = next;
-    if (!this.enablePointerLock && document.pointerLockElement === this.canvas) {
-      document.exitPointerLock();
+    if (!this.enablePointerLock) {
+      const lockedElement = getPointerLockElement();
+      if (lockedElement === this.canvas) {
+        exitPointerLock();
+      }
     }
-    this.isPointerLocked = this.enablePointerLock && document.pointerLockElement === this.canvas;
+    const lockedElement = getPointerLockElement();
+    this.isPointerLocked = this.enablePointerLock && lockedElement === this.canvas;
   }
 
   resetMovement() {
@@ -71,8 +88,12 @@ class PlayerController {
   dispose() {
     window.removeEventListener("keydown", this._onKeyDown);
     window.removeEventListener("keyup", this._onKeyUp);
-    document.removeEventListener("pointerlockchange", this._onPointerLockChange);
-    document.removeEventListener("pointerlockerror", this._onPointerLockError);
+    this._pointerLockChangeEvents.forEach((eventName) => {
+      document.removeEventListener(eventName, this._onPointerLockChange);
+    });
+    this._pointerLockErrorEvents.forEach((eventName) => {
+      document.removeEventListener(eventName, this._onPointerLockError);
+    });
     document.removeEventListener("mousemove", this._onMouseMove);
     this.canvas.removeEventListener("click", this._onCanvasClick);
   }
@@ -127,7 +148,13 @@ class PlayerController {
         this.gameState.emit("maze:regenerate");
         break;
       case "Escape":
-        document.exitPointerLock();
+      case "KeyP":
+        if (this.gameState.phase === "running") {
+          this.gameState.emit("ui:pauseRequested");
+        } else if (this.gameState.phase === "paused") {
+          this.gameState.emit("ui:resumeRequested");
+        }
+        exitPointerLock();
         break;
       default:
         break;
@@ -191,10 +218,14 @@ class PlayerController {
     if (this.gameState.phase !== "running") {
       return;
     }
-    if (!this.enablePointerLock || document.pointerLockElement === this.canvas) {
+    if (!this.enablePointerLock) {
       return;
     }
-    this.canvas.requestPointerLock();
+    const lockedElement = getPointerLockElement();
+    if (lockedElement === this.canvas) {
+      return;
+    }
+    requestPointerLock(this.canvas);
   }
 
   _normalizeAxis(value) {
@@ -225,7 +256,12 @@ class PlayerController {
   }
 
   _handlePointerLockChange() {
-    this.isPointerLocked = this.enablePointerLock && document.pointerLockElement === this.canvas;
+    const wasLocked = this.isPointerLocked;
+    const lockedElement = getPointerLockElement();
+    this.isPointerLocked = this.enablePointerLock && lockedElement === this.canvas;
+    if (wasLocked && !this.isPointerLocked && this.gameState.phase === "running") {
+      this.gameState.emit("ui:pauseRequested");
+    }
   }
 
   _handlePointerLockError() {
@@ -234,4 +270,3 @@ class PlayerController {
 }
 
 export default PlayerController;
-

--- a/js/ui/ControlOverlay.js
+++ b/js/ui/ControlOverlay.js
@@ -1,5 +1,7 @@
 const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
 
+let overlayMenuCounter = 0;
+
 class ControlOverlay {
   constructor(rootElement, options = {}) {
     this.rootElement = rootElement;
@@ -9,6 +11,7 @@ class ControlOverlay {
     this._phase = options.phase ?? "boot";
     this._enabled = options.enabled ?? false;
     this._visible = false;
+    this._menuOpen = false;
 
     this._moveState = { pointerId: null };
     this._lookState = { pointerId: null };
@@ -81,6 +84,13 @@ class ControlOverlay {
     this.menu = this.element.querySelector("[data-menu]");
     this.menuButton = this.menu.querySelector(".control-overlay__menu-button");
     this.menuPanel = this.menu.querySelector(".control-overlay__menu-panel");
+    this._menuPanelId = `control-overlay-menu-panel-${overlayMenuCounter++}`;
+    this.menuPanel.id = this._menuPanelId;
+    this.menuPanel.hidden = true;
+    this.menuPanel.setAttribute("aria-hidden", "true");
+    this.menuButton.setAttribute("aria-haspopup", "true");
+    this.menuButton.setAttribute("aria-controls", this._menuPanelId);
+    this.menuButton.setAttribute("aria-expanded", "false");
   }
 
   _bindJoysticks() {
@@ -155,10 +165,10 @@ class ControlOverlay {
 
   _bindMenu() {
     this.menuButton.addEventListener("click", () => {
-      if (this.menuPanel.hasAttribute("hidden")) {
-        this._openMenu();
-      } else {
+      if (this._menuOpen) {
         this._closeMenu();
+      } else {
+        this._openMenu();
       }
     });
 
@@ -186,11 +196,22 @@ class ControlOverlay {
   }
 
   _openMenu() {
+    if (this._menuOpen) {
+      return;
+    }
+    this._menuOpen = true;
+    this.menuPanel.hidden = false;
     this.menuPanel.removeAttribute("hidden");
+    this.menuPanel.setAttribute("aria-hidden", "false");
+    this.menuButton.setAttribute("aria-expanded", "true");
   }
 
   _closeMenu() {
+    this._menuOpen = false;
+    this.menuPanel.hidden = true;
     this.menuPanel.setAttribute("hidden", "");
+    this.menuPanel.setAttribute("aria-hidden", "true");
+    this.menuButton.setAttribute("aria-expanded", "false");
   }
 
   _updateMoveJoystick(event) {

--- a/js/ui/HUD.js
+++ b/js/ui/HUD.js
@@ -1,4 +1,4 @@
-﻿class HUD {
+class HUD {
   constructor(container, gameState) {
     this.container = container;
     this.gameState = gameState;
@@ -15,6 +15,7 @@
       <div class="hud-line" data-hud="dots">DOTS: 0</div>
       <div class="hud-line" data-hud="seed">SEED: --</div>
       <div class="hud-line" data-hud="hint">CLICK TO INITIALIZE</div>
+      <button type="button" class="hud-button" data-hud="menuToggle" aria-live="polite">MENU_LOCKED</button>
     `;
     this._elements.phase = this.container.querySelector('[data-hud="phase"]');
     this._elements.fps = this.container.querySelector('[data-hud="fps"]');
@@ -22,14 +23,31 @@
     this._elements.dots = this.container.querySelector('[data-hud="dots"]');
     this._elements.seed = this.container.querySelector('[data-hud="seed"]');
     this._elements.hint = this.container.querySelector('[data-hud="hint"]');
+    this._elements.menuToggle = this.container.querySelector('[data-hud="menuToggle"]');
+    if (this._elements.menuToggle) {
+      this._elements.menuToggle.addEventListener("click", () => this._handleMenuToggle());
+    }
+    this._syncMenuToggle();
   }
 
   _bind() {
     this.gameState.subscribe("state:phase", (phase) => {
       this._elements.phase.textContent = `STATE: ${phase.toUpperCase()}`;
-      if (phase === "running") {
-        this._elements.hint.textContent = "WASD // MOVE   MOUSE // ORIENT";
+      switch (phase) {
+        case "running":
+          this._elements.hint.textContent = "WASD // MOVE   MOUSE // ORIENT   ESC/P // MENU";
+          break;
+        case "paused":
+          this._elements.hint.textContent = "MENU ACTIVE // ESC OR BUTTON TO RESUME";
+          break;
+        case "complete":
+          this._elements.hint.textContent = "SESSION COMPLETE // REVIEW OPTIONS";
+          break;
+        default:
+          this._elements.hint.textContent = "CLICK TO INITIALIZE";
+          break;
       }
+      this._syncMenuToggle();
     });
 
     this.gameState.subscribe("stats:fps", (fps) => {
@@ -57,7 +75,35 @@
       }
     });
   }
+
+  _handleMenuToggle() {
+    const phase = this.gameState.phase;
+    if (phase === "running") {
+      this.gameState.emit("ui:pauseRequested");
+    } else if (phase === "paused") {
+      this.gameState.emit("ui:resumeRequested");
+    }
+  }
+
+  _syncMenuToggle() {
+    const button = this._elements.menuToggle;
+    if (!button) {
+      return;
+    }
+    const phase = this.gameState.phase;
+    const actionable = phase === "running" || phase === "paused";
+    button.disabled = !actionable;
+    button.setAttribute("aria-disabled", actionable ? "false" : "true");
+    button.setAttribute("aria-pressed", phase === "paused" ? "true" : "false");
+    button.classList.toggle("hud-button--active", phase === "paused");
+    if (phase === "paused") {
+      button.textContent = "RESUME_RUN";
+    } else if (phase === "running") {
+      button.textContent = "OPEN_MENU";
+    } else {
+      button.textContent = "MENU_LOCKED";
+    }
+  }
 }
 
 export default HUD;
-


### PR DESCRIPTION
## Summary
- add a pointer lock helper with vendor-prefixed fallbacks and wire the player controller to use it, including a secondary `P` key pause toggle
- surface a pause/resume button in the HUD with new styling and updated hints so desktop players have a visible menu control
- harden the mobile control overlay menu toggling and switch the core game loop to the pointer lock helper so menus always become accessible

## Testing
- Manually verified desktop pause/resume via keyboard and HUD button using Playwright
- Manually verified mobile overlay menu open/close behaviour using Playwright

------
https://chatgpt.com/codex/tasks/task_e_68ceef67bcc88324aa0c905a13b6fed0